### PR TITLE
Updated utils functions

### DIFF
--- a/utils/gsp_cheby_eval.m
+++ b/utils/gsp_cheby_eval.m
@@ -9,7 +9,6 @@ function r = gsp_cheby_eval(x,c,arange)
 %   Output parameters
 %       r       : Result
 %
-%   In this function, arrange has to be [0, lmax ]!
 %
 %   Url: https://epfl-lts2.github.io/gspbox-html/doc/utils/gsp_cheby_eval.html
 

--- a/utils/gsp_cheby_eval.m
+++ b/utils/gsp_cheby_eval.m
@@ -9,30 +9,6 @@ function r = gsp_cheby_eval(x,c,arange)
 %   Output parameters
 %       r       : Result
 %
-%
-%   Url: https://epfl-lts2.github.io/gspbox-html/doc/utils/gsp_cheby_eval.html
-
-% Copyright (C) 2013-2016 Nathanael Perraudin, Johan Paratte, David I Shuman.
-% This file is part of GSPbox version 0.7.5
-%
-% This program is free software: you can redistribute it and/or modify
-% it under the terms of the GNU General Public License as published by
-% the Free Software Foundation, either version 3 of the License, or
-% (at your option) any later version.
-%
-% This program is distributed in the hope that it will be useful,
-% but WITHOUT ANY WARRANTY; without even the implied warranty of
-% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-% GNU General Public License for more details.
-%
-% You should have received a copy of the GNU General Public License
-% along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-% If you use this toolbox please kindly cite
-%     N. Perraudin, J. Paratte, D. Shuman, V. Kalofolias, P. Vandergheynst,
-%     and D. K. Hammond. GSPBOX: A toolbox for signal processing on graphs.
-%     ArXiv e-prints, Aug. 2014.
-% http://arxiv.org/abs/1408.5781
 
 % Author: David K Hammond, Nathanael Perraudin, Li Fan, David Shuman
 % Testing: test_dual

--- a/utils/gsp_cheby_eval.m
+++ b/utils/gsp_cheby_eval.m
@@ -9,19 +9,40 @@ function r = gsp_cheby_eval(x,c,arange)
 %   Output parameters
 %       r       : Result
 %
-%   In this function, *arrange* has to be [0, lmax ]!
+%   In this function, arrange has to be [0, lmax ]!
+%
+%   Url: https://epfl-lts2.github.io/gspbox-html/doc/utils/gsp_cheby_eval.html
 
-% Author: David K Hammond, Nathanael Perraudin
+% Copyright (C) 2013-2016 Nathanael Perraudin, Johan Paratte, David I Shuman.
+% This file is part of GSPbox version 0.7.5
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+% If you use this toolbox please kindly cite
+%     N. Perraudin, J. Paratte, D. Shuman, V. Kalofolias, P. Vandergheynst,
+%     and D. K. Hammond. GSPBOX: A toolbox for signal processing on graphs.
+%     ArXiv e-prints, Aug. 2014.
+% http://arxiv.org/abs/1408.5781
+
+% Author: David K Hammond, Nathanael Perraudin, Li Fan, David Shuman
 % Testing: test_dual
-% Date: 30 December 2014
+% Date: 5 October 2018
 
 % By setting the operator L to mean (pointwise) multiplication by x,
 % and f to be vector of ones, p(L)f will contain p(x) at each
 % point. This lets us use gsp_cheby_eval to evaluate the Chebyshev polynomials.
 
-if arange(1)
-    error('This function will not work!')
-end
 
 [N1,N2] = size(x);
 
@@ -29,6 +50,7 @@ L=spdiags(x(:),0,speye(numel(x)));
 f=ones(size(x(:)));
 N = length(f);
 
+G.lmin = arange(1); 
 G.lmax = arange(2);
 G.L = L;
 G.N = N;
@@ -37,4 +59,5 @@ r = gsp_cheby_op(G, c, f);
 r = reshape(r, N1, N2);
 
 end
+
 

--- a/utils/gsp_cheby_op.m
+++ b/utils/gsp_cheby_op.m
@@ -13,7 +13,7 @@ function r = gsp_cheby_op(G, c, signal,param)
 %   Chebyshev basis) applied to input.
 %
 %   Coefficients for multiple polynomials may be passed as a matrix.
-%   This is equivalent to setting::
+%   This is equivalent to setting:
 %
 %       r(1) = gsp_cheby_op(G, c(:,1), signal);
 %       r(2) = gsp_cheby_op(G, c(:,2), signal);
@@ -41,9 +41,9 @@ function r = gsp_cheby_op(G, c, signal,param)
 %   See also: gsp_cheby_coeff gsp_filter_analysis
 %
 
-% Author: David K Hammond, Nathanael Perraudin
+% Author: David K Hammond, Nathanael Perraudin, Li Fan, David Shuman
 % Testing: test_filter
-% Date: 19 March 2014
+% Date: 5 October 2018
 
 if nargin < 4
     param = struct;
@@ -63,8 +63,11 @@ assert(all(M>=2));
 maxM=max(M);
 
 
+if ~isfield(G,'lmin')
+    G.lmin=0;
+end
 
-if ~isfield(G,'lmax');
+if ~isfield(G,'lmax')
     G = gsp_estimate_lmax(G);
     if param.verbose
     warning(['GSP_CHEBY_OP: The variable lmax is not ',...
@@ -82,7 +85,7 @@ else
     bsingle = 0;
 end
 
-arange = [0, G.lmax];
+arange = [G.lmin, G.lmax];
 
 a1 = (arange(2) - arange(1))/2;
 a2 = (arange(2) + arange(1))/2;
@@ -120,3 +123,4 @@ if bsingle
 end
 
 end
+

--- a/utils/gsp_compute_fourier_basis.m
+++ b/utils/gsp_compute_fourier_basis.m
@@ -31,32 +31,6 @@ function [G] = gsp_compute_fourier_basis(G,param)
 %     F. R. K. Chung. Spectral Graph Theory. Vol. 92 of the CBMS Regional
 %     Conference Series in Mathematics, American Mathematical Society, 1997.
 %     
-%     
-%
-%
-%   Url: https://epfl-lts2.github.io/gspbox-html/doc/utils/gsp_compute_fourier_basis.html
-
-% Copyright (C) 2013-2016 Nathanael Perraudin, Johan Paratte, David I Shuman.
-% This file is part of GSPbox version 0.7.5
-%
-% This program is free software: you can redistribute it and/or modify
-% it under the terms of the GNU General Public License as published by
-% the Free Software Foundation, either version 3 of the License, or
-% (at your option) any later version.
-%
-% This program is distributed in the hope that it will be useful,
-% but WITHOUT ANY WARRANTY; without even the implied warranty of
-% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-% GNU General Public License for more details.
-%
-% You should have received a copy of the GNU General Public License
-% along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-% If you use this toolbox please kindly cite
-%     N. Perraudin, J. Paratte, D. Shuman, V. Kalofolias, P. Vandergheynst,
-%     and D. K. Hammond. GSPBOX: A toolbox for signal processing on graphs.
-%     ArXiv e-prints, Aug. 2014.
-% http://arxiv.org/abs/1408.5781
 
 % Author : David I Shuman, Nathanael Perraudin, Li Fan
 % Testing: test_operators

--- a/utils/gsp_compute_fourier_basis.m
+++ b/utils/gsp_compute_fourier_basis.m
@@ -12,27 +12,53 @@ function [G] = gsp_compute_fourier_basis(G,param)
 %   'gsp_compute_fourier_basis(G)' computes a full eigendecomposition of the graph
 %   Laplacian G.L:
 %
-%   .. L = U Lambda U* 
+%      L = U Lambda U* 
 %
-%   .. math:: {\cal L} = U \Lambda U^*
-%
-%   where $\Lambda$ is a diagonal matrix of the Laplacian eigenvalues. 
-%   *G.e* is a column vector of length *G.N* containing the Laplacian
-%   eigenvalues. The function will store the basis *U*, the eigenvalues
-%   *e*, the maximum eigenvalue *lmax* and *G.mu* the coherence of the
-%   Fourier basis into the structure *G*.
+%   where Lambda is a diagonal matrix of the Laplacian eigenvalues. 
+%   G.e is a column vector of length G.N containing the Laplacian
+%   eigenvalues. The function will store the basis U, the eigenvalues
+%   e, the maximum eigenvalue lmax and G.mu the coherence of the
+%   Fourier basis into the structure G.
 % 
-%   Example:::
+%   Example:
 %
 %       N = 50;
 %       G = gsp_sensor(N);
 %       G = gsp_compute_fourier_basis(G);
 %       gsp_plot_signal(G,G.U(:,2));
 % 
-%   References: chung1997spectral
+%   References:
+%     F. R. K. Chung. Spectral Graph Theory. Vol. 92 of the CBMS Regional
+%     Conference Series in Mathematics, American Mathematical Society, 1997.
+%     
+%     
 %
+%
+%   Url: https://epfl-lts2.github.io/gspbox-html/doc/utils/gsp_compute_fourier_basis.html
 
-% Author : David I Shuman, Nathanael Perraudin
+% Copyright (C) 2013-2016 Nathanael Perraudin, Johan Paratte, David I Shuman.
+% This file is part of GSPbox version 0.7.5
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+% If you use this toolbox please kindly cite
+%     N. Perraudin, J. Paratte, D. Shuman, V. Kalofolias, P. Vandergheynst,
+%     and D. K. Hammond. GSPBOX: A toolbox for signal processing on graphs.
+%     ArXiv e-prints, Aug. 2014.
+% http://arxiv.org/abs/1408.5781
+
+% Author : David I Shuman, Nathanael Perraudin, Li Fan
 % Testing: test_operators
 
 if nargin < 2
@@ -49,6 +75,7 @@ if numel(G)>1
 end
 
 if ~isfield(param,'verbose'), param.verbose = 1; end
+if ~isfield(param,'force_svd'), param.force_svd = 0; end
 
 
 
@@ -88,7 +115,7 @@ else
     if ~isfield(G,'L')
         error('Graph Laplacian is not provided.');
     end
-    [G.U, G.e] = gsp_full_eigen(G.L);
+    [G.U, G.e] = gsp_full_eigen(G.L,param);
 end
 
 G.lmax=max(G.e);
@@ -104,16 +131,20 @@ G.mu = max(abs(G.U(:)));
 end
 
 
-function [U,E] = gsp_full_eigen(L)
+function [U,E] = gsp_full_eigen(L, param) 
 %GSP_FULL_EIGEN Compute and order the eigen decomposition of L
 
-    % Compute and all eigenvalues and eigenvectors 
-%     try
-%         [eigenvectors,eigenvalues]=eig(full(L+L')/2);
-%     catch
+    % Compute and all eigenvalues and eigenvectors
+    if param.force_svd
         [eigenvectors,eigenvalues,~]=svd(full(L+L')/2);
-%     end
-    
+    else   
+        try
+            [eigenvectors,eigenvalues]=eig(full(L+L')/2);
+        catch
+            [eigenvectors,eigenvalues,~]=svd(full(L+L')/2);
+        end
+    end
+
     % Sort eigenvectors and eigenvalues
     [E,inds] = sort(diag(eigenvalues),'ascend');
     eigenvectors=eigenvectors(:,inds);
@@ -132,3 +163,4 @@ n = signal.internal.sigcasttofloat(n,'double','dftmtx','N',...
 D = fft(eye(n));
 
 end
+


### PR DESCRIPTION
Updates:
1. gsp_cheby_eval: Allow for arange to start at nonzero value
2. gsp_cheby_op: Allow for arange to start at nonzero value
3. gsp_compute_fourier_basis: Introduced parameter option to force it to use svd instead of eig